### PR TITLE
PMID parsing issue

### DIFF
--- a/pymed/article.py
+++ b/pymed/article.py
@@ -47,7 +47,7 @@ class PubMedArticle(object):
                 self.__setattr__(field, kwargs.get(field, None))
 
     def _extractPubMedId(self: object, xml_element: TypeVar("Element")) -> str:
-        path = ".//ArticleId[@IdType='pubmed']"
+        path = ".//PubmedData/ArticleIdList/ArticleId[@IdType='pubmed']"
         return getContent(element=xml_element, path=path)
 
     def _extractTitle(self: object, xml_element: TypeVar("Element")) -> str:


### PR DESCRIPTION
This will fix the PMID parsing issue in articles for which currently multiple PMID's are getting parsed. Those other id's are likely the PMID's of cited articles in the article under consideration.
resolves gijswobben/pymed#22

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests (if applicable)?
2. [ ] Have you lint your code locally prior to submission (use flake8)?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
